### PR TITLE
Fix root path, add options

### DIFF
--- a/example/example.js
+++ b/example/example.js
@@ -2,7 +2,7 @@ var serve = require("../"),
     koa = require('koa');
 var app = koa();
 
-app.use(serve('./example', 'test'));  // Path of folder, path you want to serve under.
+app.use(serve('./example', 'test', { index: 'root.html' }));  // Path of folder, path you want to serve under.
 
 app.use(function *(next) {
     if (this.path == '/') {

--- a/example/example/root.html
+++ b/example/example/root.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+       <title>koa-smart-static example</title>
+</head>
+<body>
+       Try accessing <a href="/test/1/test.html">/test/1/test.html</a>, <a href="/test/2/test.txt">/test/2/test.txt</a>, or <a href="/test/3/test.json">/test/3/test.json</a>
+</body>
+</html>

--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@ var send = require('koa-send'),
     fs = require('fs'),
     path = require('path');
 
-function serve(root, servePath) {
+function serve(root, servePath, options) {
+    options = options || {};
     return function * staticFolder(next){
         var convertedPath = this.path.slice(1).split("/");
 
@@ -14,8 +15,12 @@ function serve(root, servePath) {
                     path = '/';
                 }
 
-                return yield send(this, path, {root: root});
+                var opts = {
+                    root: root,
+                    index: options.index || 'index.html'
+                };
 
+                return yield send(this, path, opts);
             } catch (err) {
             }
         }

--- a/index.js
+++ b/index.js
@@ -8,7 +8,14 @@ function serve(root, servePath) {
 
         if (convertedPath[0] == servePath) {
             try {
-                return yield send(this, convertedPath.slice(1).join('/'), {root: root});
+                var path = convertedPath.slice(1).join('/');
+                //if path is empty string - we're going to the root
+                if (path === '') {
+                    path = '/';
+                }
+
+                return yield send(this, path, {root: root});
+
             } catch (err) {
             }
         }


### PR DESCRIPTION
There're 2 improvements in this PR:
1. Add support for the root path. The problem was with code like

```
app.use(serve('./example', 'test'));

GET /test/
```

Now it'll resolve such path into `/` and pass to `koa-send`
1. `koa-send` supports **index** option: the default file. So the ability to set such kind of options has been added as well. The syntax is:

```
app.use(serve('./example', 'test', { index: 'root.html' }));

GET /test/    ----> /test/root.html
```
